### PR TITLE
Fix Linux build errors

### DIFF
--- a/indra/newview/rlvdefines.h
+++ b/indra/newview/rlvdefines.h
@@ -102,7 +102,7 @@ namespace Rlv
 
     enum class EBehaviourOptionType
     {
-        None,                               // Behaviour takes no parameters
+        EmptyOrException,                   // Behaviour takes no parameters
         Exception,                          // Behaviour requires an exception as a parameter
         NoneOrException,                    // Behaviour takes either no parameters or an exception
     };
@@ -120,7 +120,7 @@ namespace Rlv
     enum class ECmdRet {
         Unknown = 0x0000,               // Unknown error (should only be used internally)
         Retained,                       // Command was retained
-        Success = 0x0100,               // Command executed successfully
+        Succeeded = 0x0100,             // Command executed successfully
         SuccessUnset,                   // Command executed successfully (RLV_TYPE_REMOVE for an unrestricted behaviour)
         SuccessDuplicate,               // Command executed successfully (RLV_TYPE_ADD for an already restricted behaviour)
         SuccessDeprecated,              // Command executed successfully but has been marked as deprecated
@@ -163,7 +163,7 @@ namespace Rlv
 
     constexpr bool isReturnCodeSuccess(ECmdRet eRet)
     {
-        return (to_underlying(eRet) & to_underlying(ECmdRet::Success)) == to_underlying(ECmdRet::Success);
+        return (to_underlying(eRet) & to_underlying(ECmdRet::Succeeded)) == to_underlying(ECmdRet::Succeeded);
     }
 
     constexpr bool isReturnCodeFailed(ECmdRet eRet)

--- a/indra/newview/rlvhandler.cpp
+++ b/indra/newview/rlvhandler.cpp
@@ -198,7 +198,7 @@ ECmdRet ReplyHandler<EBehaviour::GetCommand>::onCommand(const RlvCommand& rlvCmd
     std::list<std::string> cmdList;
     if (BehaviourDictionary::instance().getCommands(!optionList.empty() ? optionList[0] : LLStringUtil::null, eType, cmdList))
         strReply = boost::algorithm::join(cmdList, optionList.size() >= 3 ? optionList[2] : Constants::OptionSeparator);
-    return ECmdRet::Success;
+    return ECmdRet::Succeeded;
 }
 
 // Handles: @version=<chnannel> and @versionnew=<channel>
@@ -206,7 +206,7 @@ template<> template<>
 ECmdRet VersionReplyHandler::onCommand(const RlvCommand& rlvCmd, std::string& strReply)
 {
     strReply = Strings::getVersion(EBehaviour::Version == rlvCmd.getBehaviourType());
-    return ECmdRet::Success;
+    return ECmdRet::Succeeded;
 }
 
 // Handles: @versionnum[:impl]=<channel>
@@ -219,7 +219,7 @@ ECmdRet ReplyHandler<EBehaviour::VersionNum>::onCommand(const RlvCommand& rlvCmd
         strReply = Strings::getVersionImplNum();
     else
         return ECmdRet::FailedOption;
-    return ECmdRet::Success;
+    return ECmdRet::Succeeded;
 }
 
 // ============================================================================

--- a/indra/newview/rlvhelper.cpp
+++ b/indra/newview/rlvhelper.cpp
@@ -283,7 +283,7 @@ namespace Rlv
         else if (mForConsole)
             return; // Only show console feedback on successful commands when there's an informational notice
 
-        std::string& strResult = mCommandResults[isReturnCodeSuccess(eRet) ? ECmdRet::Success : (ECmdRet::Retained == eRet ? ECmdRet::Retained : ECmdRet::Failed)];
+        std::string& strResult = mCommandResults[isReturnCodeSuccess(eRet) ? ECmdRet::Succeeded : (ECmdRet::Retained == eRet ? ECmdRet::Retained : ECmdRet::Failed)];
         if (!strResult.empty())
             strResult.append(", ");
         strResult.append(strCmd);
@@ -308,7 +308,7 @@ namespace Rlv
                 };
             if (!mForConsole)
                 result << ": @" << mOrigCmd;
-            appendResult(ECmdRet::Success, !mForConsole ? "RlvDebugExecuted" : "RlvConsoleExecuted");
+            appendResult(ECmdRet::Succeeded, !mForConsole ? "RlvDebugExecuted" : "RlvConsoleExecuted");
             appendResult(ECmdRet::Failed, !mForConsole ? "RlvDebugFailed" : "RlvConsoleFailed");
             appendResult(ECmdRet::Retained, !mForConsole ? "RlvDebugRetained" : "RlvConsoleRetained");
         }
@@ -320,7 +320,7 @@ namespace Rlv
     {
         switch (eRet)
         {
-            case ECmdRet::Success:
+            case ECmdRet::Succeeded:
                 return LLTrans::getString("RlvDebugExecuted");
             case ECmdRet::Failed:
                 return LLTrans::getString("RlvDebugFailed");
@@ -372,7 +372,7 @@ namespace Rlv
                 return LLTrans::getString("RlvReturnCodeNoProcessor");
             // The following are identified by the chat verb
             case ECmdRet::Retained:
-            case ECmdRet::Success:
+            case ECmdRet::Succeeded:
             case ECmdRet::Failed:
                 return LLStringUtil::null;
             // The following shouldn't occur


### PR DESCRIPTION
Replace None and Success. Those are X11 defines and thus lead to compile errors when compiling a Linux viewer.